### PR TITLE
Support Luck

### DIFF
--- a/common/src/main/java/tech/thatgravyboat/lootbags/api/LootTableOutput.java
+++ b/common/src/main/java/tech/thatgravyboat/lootbags/api/LootTableOutput.java
@@ -27,6 +27,7 @@ public record LootTableOutput(ResourceLocation table) implements LootOutput {
         if (player.level() instanceof ServerLevel serverLevel) {
             LootParams params = new LootParams.Builder(serverLevel)
                     .withOptionalParameter(LootContextParams.THIS_ENTITY, player)
+                    .withLuck(player.getLuck())
                     .withParameter(LootContextParams.ORIGIN, player.position())
                     .create(LootContextParamSets.CHEST);
             LootTable lootTable = serverLevel.getServer().getLootData().getLootTable(table);


### PR DESCRIPTION
Tested with the following recipe:
```
{
    "type": "lootbags:loot",
    "name": "Lootbag of Fishing",
    "rarity": "UNCOMMON",
    "output": {
        "table": "minecraft:gameplay/fishing"
    }
}
```
/effect give @p luck infinite 10 will guarantee that lootbag doesn't give items from the "junk" table